### PR TITLE
Update data-proxy branch to 3.15.2 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Vercel deployment example
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fprisma%2Fdeployment-example-vercel%2Ftree%2Fdata-proxy&env=DATABASE_URL,MIGRATE_DATABASE_URL&envDescription=DATABASE_URL%20-%20proxy%20URL%2C%20MIGRATE_DATABASE_URL%20-%20direct%20connection%20string&envLink=https%3A%2F%2Fwww.notion.so%2Fprismaio%2FPrisma-Data-Proxy-Early-Access-Program-EAP-8ca06a8b350340e3a6236689375d071e)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fprisma%2Fdeployment-example-vercel%2Ftree%2Fdata-proxy&env=DATABASE_URL,MIGRATE_DATABASE_URL,PRISMA_GENERATE_DATAPROXY&envDescription=DATABASE_URL%20-%20Data%20Proxy%20URL%2C%20MIGRATE_DATABASE_URL%20-%20direct%20connection%20string%2C%20PRISMA_GENERATE_DATAPROXY%20-%20always%20set%20to%20%60true%60%20so%20Vercel%20generates%20a%20Data%20Proxy%20Client&envLink=https%3A%2F%2Fwww.prisma.io%2Fdocs%2Fconcepts%2Fdata-platform%2Fdata-proxy%23using-the-data-proxy-in-a-prisma-application)
 
-[Deployment guide](https://www.prisma.io/docs/guides/deployment/deploying-to-vercel)
+- [Deployment guide](https://www.prisma.io/docs/guides/deployment/deploying-to-vercel)
+- [Data Proxy specific instructions](https://www.prisma.io/docs/concepts/data-platform/data-proxy#deploying-to-vercel-serverless-functions)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deployment-example-prisma-vercel",
   "dependencies": {
-    "@prisma/client": "^3.15.1",
+    "@prisma/client": "3.15.1",
     "next": "11.1.2",
     "react": "17.0.2",
     "react-dom": "17.0.2"
@@ -15,6 +15,6 @@
     "prisma:migrate": "DATABASE_URL=\"$MIGRATE_DATABASE_URL\" prisma migrate deploy"
   },
   "devDependencies": {
-    "prisma": "^3.15.1"
+    "prisma": "3.15.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deployment-example-prisma-vercel",
   "dependencies": {
-    "@prisma/client": "3.3.0",
+    "@prisma/client": "^3.15.1",
     "next": "11.1.2",
     "react": "17.0.2",
     "react-dom": "17.0.2"
@@ -11,10 +11,10 @@
     "build": "next build",
     "start": "next start",
     "vercel-build": "npm run prisma:generate && npm run prisma:migrate && next build",
-    "prisma:generate": "PRISMA_CLIENT_ENGINE_TYPE='dataproxy' prisma generate",
+    "prisma:generate": "prisma generate --data-proxy",
     "prisma:migrate": "DATABASE_URL=\"$MIGRATE_DATABASE_URL\" prisma migrate deploy"
   },
   "devDependencies": {
-    "prisma": "3.3.0"
+    "prisma": "^3.15.1"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
-  provider        = "prisma-client-js"
-  previewFeatures = ["dataProxy"]
+  provider = "prisma-client-js"
 }
 
 datasource db {


### PR DESCRIPTION
(not actually on 3.15.2 yet as that does not exist yet)

To test deploying this branch: https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fprisma%2Fdeployment-example-vercel%2Ftree%2Fjanpio%2Fdata-proxy-ga&env=DATABASE_URL,MIGRATE_DATABASE_URL,PRISMA_GENERATE_DATAPROXY&envDescription=DATABASE_URL%20-%20Data%20Proxy%20URL%2C%20MIGRATE_DATABASE_URL%20-%20direct%20connection%20string%2C%20PRISMA_GENERATE_DATAPROXY%20-%20always%20set%20to%20%60true%60%20so%20Vercel%20generates%20a%20Data%20Proxy%20Client&envLink=https%3A%2F%2Fwww.prisma.io%2Fdocs%2Fconcepts%2Fdata-platform%2Fdata-proxy%23using-the-data-proxy-in-a-prisma-application